### PR TITLE
Feature title available in the parser results. Updated Casper example to make use of the feature title as a Casper spec title

### DIFF
--- a/examples/casper/spec/google-spec.txt
+++ b/examples/casper/spec/google-spec.txt
@@ -1,3 +1,5 @@
+Feature: Multilingual Google Search
+
 Scenario: Searching Google
 
     When I open Google's fr search page

--- a/examples/casper/test.js
+++ b/examples/casper/test.js
@@ -3,7 +3,6 @@
 
 var fs = require('fs');
 var async = require('async');
-var casper = require('casper').create();
 
 // var Yadda = require('yadda');
 var Yadda = require('../../lib/index.js');
@@ -16,25 +15,22 @@ var library = require('./google-library').init();
 var yadda = new Yadda.Yadda(library);
 Yadda.plugins.casper(yadda, casper);
 
-function bySpecification(file) {
-    return file.substr(-9) === '-spec.txt';
-};
-
 function loadScenarios(file) {
     var parser = new TextParser();
     var text = fs.read(file);
     return parser.parse(text);
 };
 
-var scenarios = loadScenarios('./spec/bottles-spec.txt');
-async.eachSeries(scenarios, function(scenario, next) {
-    casper.start();
-    casper.test.info(scenario.title);
-    casper.yadda(scenario.steps);
-    casper.run(function() {
-        next();
+var feature = loadScenarios('./spec/google-spec.txt');
+casper.test.begin(feature.title, function suite(test) {
+    async.eachSeries(feature.scenarios, function(scenario, next) {
+        casper.start();
+        casper.test.info(scenario.title);
+        casper.yadda(scenario.steps);
+        casper.run(function() {
+            next();
+        });
+    }, function(err) {
+        casper.test.done();
     });
-}, function(err) {
-    casper.test.done();
-    casper.test.renderResults(true);
 });

--- a/examples/nodeunit/test.js
+++ b/examples/nodeunit/test.js
@@ -12,7 +12,7 @@ function eachScenario(dir, fn) {
     var parser = new TextParser();        
     var scenarios = fs.readdirSync(dir).filter(bySpecification).forEach(function(file) {
         var text = fs.readFileSync(path.join(dir, file), 'utf8');
-        var scenarios = parser.parse(text);
+        var scenarios = parser.parse(text).scenarios;
         for (var i = 0; i < scenarios.length; i++) {
             fn(scenarios[i]);
         };

--- a/examples/qunit/test.html
+++ b/examples/qunit/test.html
@@ -13,7 +13,7 @@
 
         function runTests() {
             var text = document.getElementById('scenarios').innerText;
-            var scenarios = new TextParser().parse(text);
+            var scenarios = new TextParser().parse(text).scenarios;
             for (var i = 0; i < scenarios.length; i++) {
                 var scenario = scenarios[i];
                 test(scenario.title, function() {

--- a/lib/parsers/TextParser.js
+++ b/lib/parsers/TextParser.js
@@ -34,7 +34,7 @@ var TextParser = function() {
         split(text).each(function(line) {
             parse_line(line);
         });
-        return scenarios;
+        return {title: current_feature, scenarios: scenarios};
     };
 
     var split = function(text) {

--- a/lib/plugins/MochaPlugin.js
+++ b/lib/plugins/MochaPlugin.js
@@ -22,8 +22,8 @@ module.exports = function(options) {
         describe(name, function() {            
             var text = fs.readFileSync(filename, 'utf8');
             try {
-                var scenarios = parser.parse(text);
-                runScenarios(scenarios);
+                var feature = parser.parse(text);
+                runScenarios(feature.scenarios);
             } catch (e) {
                 throw new Error(e);
             }                 

--- a/test/TextParserTests.js
+++ b/test/TextParserTests.js
@@ -14,37 +14,34 @@ describe('TextPaser', function() {
     });
 
     it('should parse a simple scenario', function() {
-        var scenarios = parser.parse(simple_scenario);
+        var scenarios = parser.parse(simple_scenario).scenarios;
         assert.equal(scenarios.length, 1);
         assert.equal(scenarios[0].title, 'Simple');
         assert.deepEqual(scenarios[0].steps, ['Given A', 'When B', 'Then C']);
     });
 
     it('should parse a complex scenario', function() {
-        var parser = new TextParser();
-        var scenarios = parser.parse(complex_scenario);
+        var scenarios = parser.parse(complex_scenario).scenarios;
         assert.equal(scenarios.length, 1);
         assert.equal(scenarios[0].title, 'Complex');
         assert.deepEqual(scenarios[0].steps, ['Given A', 'When B', 'Then C']);
     });
 
     it('should parses multiple scenarios', function() {
-        var parser = new TextParser();
-        var scenarios = parser.parse(simple_scenario + '\n' + complex_scenario);
+        var scenarios = parser.parse(simple_scenario + '\n' + complex_scenario).scenarios;
         assert.equal(scenarios.length, 2);
         assert.equal(scenarios[0].title, 'Simple');
         assert.equal(scenarios[1].title, 'Complex');
     });
 
     it('should reset scenarios between parses', function() {
-        assert.equal(parser.parse(simple_scenario).length, 1);
-        assert.equal(parser.parse(simple_scenario).length, 1);
+        assert.equal(parser.parse(simple_scenario).scenarios.length, 1);
+        assert.equal(parser.parse(simple_scenario).scenarios.length, 1);
     });
 
-    it('should ignore feature blocks', function() {
-        var scenarios = parser.parse(simple_feature);
-        assert.equal(scenarios.length, 1);
-        assert.equal(scenarios[0].title, 'With Feature');
+    it('should parse feature title', function() {
+        var feature = parser.parse(simple_feature);
+        assert.equal(feature.title, 'Tests with feature');
     });
 
     it('should only allow a single feature', function() {


### PR DESCRIPTION
We've just started using Yadda in combination with CasperJS for our E2E testing. I hope it's ok if I'll be creating some pull requests once in awhile.
Feature title is something that we are lacking as we run multiple feature files at once and scenarios are difficult to tell apart.
