### PR TITLE
Scenarios can be marked as ignored by prefixing them with 'Pending'

### DIFF
--- a/examples/casper/spec/google-spec.txt
+++ b/examples/casper/spec/google-spec.txt
@@ -21,3 +21,9 @@ Scenario: Searching Google Again
     then the title is bar - Google Search
     and the search for bar was made
     and 10 or more results were returned    
+
+Pending Scenario: Breaking Google
+
+    Given I navigate to Google main page
+    When I search for 'Prohibited phrase'
+    Then the error details are displayed

--- a/examples/casper/test.js
+++ b/examples/casper/test.js
@@ -21,12 +21,20 @@ function loadScenarios(file) {
     return parser.parse(text);
 };
 
+function executeSteps(scenario) {
+    if (scenario.pending) {
+        casper.test.pass('Scenario is PENDING');
+        casper.thenBypass(scenario.steps.length);
+    }
+    casper.yadda(scenario.steps);
+};
+
 var feature = loadScenarios('./spec/google-spec.txt');
 casper.test.begin(feature.title, function suite(test) {
     async.eachSeries(feature.scenarios, function(scenario, next) {
         casper.start();
         casper.test.info(scenario.title);
-        casper.yadda(scenario.steps);
+        executeSteps(scenario);
         casper.run(function() {
             next();
         });

--- a/lib/parsers/TextParser.js
+++ b/lib/parsers/TextParser.js
@@ -17,25 +17,68 @@
 var $ = require('../Array');
 
 var TextParser = function() {
-
     var FEATURE_REGEX = /^\s*Feature:\s*(.*)/i;
     var SCENARIO_REGEX = /^\s*Scenario:\s*(.*)/i;
+    var PENDING_SCENARIO_REGEX = /^\s*Pending\s*Scenario:\s*(.*)/i;
     var STEP_REGEX = /^\s*([^\s].*)/;
     var NON_BLANK_REGEX = /[^\s]/;
 
-    var current_feature;
-    var current_scenario;
-    var scenarios;
-
     this.parse = function(text) {
-        current_scenario = {};
-        current_feature = null;
-        scenarios = [];
-        split(text).each(function(line) {
-            parse_line(line);
+        var new_feature = { scenarios: [], last_scenario: function() { return this.scenarios[this.scenarios.length - 1] } };
+        
+        return split(text).inject(new_feature, function(feature_so_far, line) {
+            return parse_line(feature_so_far, line);
         });
-        return {title: current_feature, scenarios: scenarios};
     };
+
+    var dispatch = function() {
+        var handlers = arguments;
+        
+        return function(feature, line) {
+            for (var handlerIdx = 0; handlerIdx < handlers.length; handlerIdx++) {
+                var handler = handlers[handlerIdx];
+                
+                var augmented_feature = handler(feature, line);
+                if (augmented_feature) return augmented_feature;
+            };
+        };
+    };
+    
+    var line_handler = function(regex, handle_function) {
+        return function(feature, line) {
+            var match = regex.exec(line);
+            
+            if (match) {
+                handle_function(feature, match);
+                return feature;
+            }
+        };
+    };
+
+    var handle_feature_line = function(feature, match) {
+        if (feature.title) throw "You can only specify a single feature";
+        feature.title = match[1];
+    };
+    
+    var handle_scenario_line = function(feature, match) {
+        feature.scenarios.push({ title: match[1], steps: [] });
+    }
+    
+    var handle_pending_scenario_line = function(feature, match) {
+        handle_scenario_line(feature, match);
+        feature.last_scenario().pending = true;
+    }
+    
+    var handle_step_line = function(feature, match) {;
+        feature.last_scenario().steps.push(match[1]);
+    };
+    
+    var parse_line = dispatch(
+        line_handler(FEATURE_REGEX, handle_feature_line),
+        line_handler(PENDING_SCENARIO_REGEX, handle_pending_scenario_line),
+        line_handler(SCENARIO_REGEX, handle_scenario_line),
+        line_handler(STEP_REGEX, handle_step_line)
+    );
 
     var split = function(text) {
         return $(text.split(/\n/)).find_all(non_blanks);
@@ -45,18 +88,6 @@ var TextParser = function() {
         return text && NON_BLANK_REGEX.test(text);
     };
 
-    var parse_line = function(line) {
-        var match;
-        if (match = FEATURE_REGEX.exec(line)) {
-            if (current_feature != null) throw "You can only specify a single feature";
-            current_feature = match[1];
-        } else if (match = SCENARIO_REGEX.exec(line)) {
-            current_scenario = { title: match[1], steps: [] };
-            scenarios.push(current_scenario);
-        } else if (match = STEP_REGEX.exec(line)) {
-            current_scenario.steps.push(match[1]);
-        }
-    };
 };
 
 module.exports = TextParser;

--- a/test/TextParserTests.js
+++ b/test/TextParserTests.js
@@ -7,6 +7,7 @@ describe('TextPaser', function() {
     var simple_feature = ['Feature: Tests with feature', 'Scenario: With Feature'].join('\n');
     var multiple_feature = ['Feature: Tests with 2 features', 'Scenario: For Feature 1', 'Feature: Second feature'].join('\n');
     var complex_scenario = ['Scenario: Complex', '', '  ', '   Given A', '', 'When B', ' ', '   Then C'].join('\n');
+    var pending_scenario = ['Pending   Scenario: Simplest', 'Then do nothing'].join('\n');
     var parser;
 
     beforeEach(function(){
@@ -16,8 +17,7 @@ describe('TextPaser', function() {
     it('should parse a simple scenario', function() {
         var scenarios = parser.parse(simple_scenario).scenarios;
         assert.equal(scenarios.length, 1);
-        assert.equal(scenarios[0].title, 'Simple');
-        assert.deepEqual(scenarios[0].steps, ['Given A', 'When B', 'Then C']);
+        assert.deepEqual(scenarios[0], { title: 'Simple', steps: ['Given A', 'When B', 'Then C'] });
     });
 
     it('should parse a complex scenario', function() {
@@ -48,5 +48,10 @@ describe('TextPaser', function() {
         assert.throws(function() {
             parser.parse(multiple_feature);
         }, /single feature/);
+    });
+    
+    it('should parse pending scenario', function() {
+        var scenarios = parser.parse(pending_scenario).scenarios;
+        assert.equal(scenarios[0].pending, true);
     });
 });


### PR DESCRIPTION
This pull request allows (as least for us) to do proper ATDD. I.e. define a scenario first, see it failing then do incremental changes to the production code until the scenario becomes green. So a scenario can remain in the 'pending' state and be merged to master without breaking CI builds.

There're other possible applications of the 'pending' scenario annotation.

You may find the TextParser refactoring quite intrusive - I don't mind if you throw it away and replace it with old (not very elegant) switch statement.

The change should be transparent for the existing library clients.
