### PR TITLE
allow for additional whitespace in localisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 npm-debug.log
 *.swp
 *.swo
+*.iml

--- a/lib/localisation/English.js
+++ b/lib/localisation/English.js
@@ -23,21 +23,21 @@ var English = function(dictionary, library) {
 
     library.given = function(signatures, fn, ctx) {
         return $(signatures).each(function(signature) {
-            var signature = prefix_signature('(?:[Gg]iven|[Ww]ith|[Aa]nd|[Bb]ut|[Ee]xcept) ', signature);
+            var signature = prefix_signature('(?:[Gg]iven|[Ww]ith|[Aa]nd|[Bb]ut|[Ee]xcept)\\s+', signature);
             return library.define(signature, fn, ctx);
         });
     };
 
     library.when = function(signatures, fn, ctx) {
         return $(signatures).each(function(signature) {
-            var signature = prefix_signature('(?:[Ww]hen|[Ii]f|[Aa]nd|[Bb]ut) ', signature);
+            var signature = prefix_signature('(?:[Ww]hen|[Ii]f|[Aa]nd|[Bb]ut)\\s+', signature);
             return library.define(signature, fn, ctx);
         });
     };
 
     library.then = function(signatures, fn, ctx) {
         return $(signatures).each(function(signature) {
-            var signature = prefix_signature('(?:[Tt]hen|[Ee]xpect|[Aa]nd|[Bb]ut) ', signature);
+            var signature = prefix_signature('(?:[Tt]hen|[Ee]xpect|[Aa]nd|[Bb]ut)\\s+', signature);
             return library.define(signature, fn, ctx);
         });
     };

--- a/lib/localisation/Pirate.js
+++ b/lib/localisation/Pirate.js
@@ -24,21 +24,21 @@ var Pirate = function(dictionary, library) {
 
     library.given = function(signatures, fn, ctx) {
         return $(signatures).each(function(signature) {
-            var signature = prefix_signature('(?:[Gg]iveth|[Ww]ith|[Aa]nd|[Bb]ut) ', signature);
+            var signature = prefix_signature('(?:[Gg]iveth|[Ww]ith|[Aa]nd|[Bb]ut)\\s+', signature);
             return library.define(signature, fn, ctx);
         });
     };
 
     library.when = function(signatures, fn, ctx) {
         return $(signatures).each(function(signature) {
-            var signature = localisation.prefix_signature('(?:[Ww]hilst|[Aa]nd|[Bb]ut) ', signature);
+            var signature = localisation.prefix_signature('(?:[Ww]hilst|[Aa]nd|[Bb]ut)\\s+', signature);
             return library.define(signature, fn, ctx);
         });
     };
 
     library.then = function(signatures, fn, ctx) {
         return $(signatures).each(function(signature) {
-            var signature = prefix_signature('(?:[Tt]hence|[Dd]emand|[Aa]nd|[Bb]ut) ', signature);
+            var signature = prefix_signature('(?:[Tt]hence|[Dd]emand|[Aa]nd|[Bb]ut)\\s+', signature);
             return library.define(signature, fn, ctx);
         });
     };

--- a/test/LibraryTests.js
+++ b/test/LibraryTests.js
@@ -75,16 +75,18 @@ describe('Library', function() {
 
         var givens = [
             'Given a wall with 100 bottles',
-            'Given a wall with 100 bottles',
+            'given a wall with 100 bottles',
             'And a wall with 100 bottles',
-            'and a wall with 100 bottles'
+            'and a wall with 100 bottles',
+            'with   a wall with 100 bottles'
         ];
 
         var whens = [
             'When 1 bottle accidentally falls',
             'when 1 bottle accidentally falls',
             'and 1 bottle accidentally falls',
-            'And 1 bottle accidentally falls'
+            'And 1 bottle accidentally falls',
+            'but  1 bottle accidentally falls'
         ];
 
         var thens = [
@@ -93,12 +95,13 @@ describe('Library', function() {
             'And there are 99 bottles left',
             'and there are 99 bottles left',
             'Expect there are 99 bottles left',
-            'expect there are 99 bottles left'
+            'expect there are 99 bottles left',
+            'but  there are 99 bottles left'
         ];
 
-        assert_localisation(library, givens, '/(?:[Gg]iven|[Ww]ith|[Aa]nd|[Bb]ut|[Ee]xcept) a wall with (\\d+) bottles/');
-        assert_localisation(library, whens, '/(?:[Ww]hen|[Ii]f|[Aa]nd|[Bb]ut) (\\d+) bottle(?:s)? accidentally falls/');
-        assert_localisation(library, thens, '/(?:[Tt]hen|[Ee]xpect|[Aa]nd|[Bb]ut) there are (\\d+) bottles left/');
+        assert_localisation(library, givens, '/(?:[Gg]iven|[Ww]ith|[Aa]nd|[Bb]ut|[Ee]xcept)\\s+a wall with (\\d+) bottles/');
+        assert_localisation(library, whens, '/(?:[Ww]hen|[Ii]f|[Aa]nd|[Bb]ut)\\s+(\\d+) bottle(?:s)? accidentally falls/');
+        assert_localisation(library, thens, '/(?:[Tt]hen|[Ee]xpect|[Aa]nd|[Bb]ut)\\s+there are (\\d+) bottles left/');
     });
 
     it('should supports localised aliased macros', function() {


### PR DESCRIPTION
```
Feature: formatted feature file
  In order to structure the feature file
  As a feature write
  I want to apply some basic formatting

Scenario: Justify lines 1
# This is already working
  Given a feature file
    And some love for justification
   When I want to justify the sentences
    And use some extra spaces
   Then the parser should be happy with it


Scenario: Justify lines 2
# And this will be with this patch
  Given a feature file
  And   some love for justification
  When  I want to justify the sentences
  And   use some extra spaces
  Then  the parser should be happy with it
```
