### PR TITLE
Added support for BDD specification in Norwegian

### DIFF
--- a/lib/localisation/Norwegian.js
+++ b/lib/localisation/Norwegian.js
@@ -1,0 +1,54 @@
+﻿/*
+ * Copyright 2010 Acuminous Ltd / Energized Work Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Library = require('../Library');
+var $ = require('../Array');
+   
+var Norwegian = function(dictionary, library) {
+
+    var library = library ? library : new Library(dictionary);
+
+    library.given = library.gitt = function(signatures, fn, ctx) {
+        return $(signatures).each(function(signature) {
+            var signature = prefix_signature('(?:[Gg]itt|[Mm]ed|[Oo]g|[Mm]en|[Uu]nntatt) ', signature);
+            return library.define(signature, fn, ctx);
+        });
+    };
+
+    library.when = library.når = function(signatures, fn, ctx) {
+        return $(signatures).each(function(signature) {
+            var signature = prefix_signature('(?:[Nn]år|[Oo]g|[Mm]en) ', signature);
+            return library.define(signature, fn, ctx);
+        });
+    };
+
+    library.then = library.så = function(signatures, fn, ctx) {
+        return $(signatures).each(function(signature) {
+            var signature = prefix_signature('(?:[Ss]å|[Ff]forvent|[Oo]g|[Mm]en) ', signature);
+            return library.define(signature, fn, ctx);
+        });
+    };
+
+    function prefix_signature(prefix, signature) {
+        var regex_delimiters = new RegExp('^/|/$', 'g');
+        var start_of_signature = new RegExp(/^(?:\^)?/);
+        return signature.toString().replace(regex_delimiters, '').replace(start_of_signature, prefix);
+    };
+
+    return library;
+};
+
+module.exports = Norwegian;

--- a/lib/localisation/index.js
+++ b/lib/localisation/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     English: require('./English'),
+    Norwegian: require('./Norwegian'),
     Pirate: require('./Pirate')
 
 }


### PR DESCRIPTION
Added a language file for Norwegian and added it to the language index.

Anything else that needs that to be done to add a language/dialect? Is a localized example needed?

Please note that Norwegian special characters require a charset that supports them, otherwise they (æøå ÆØÅ) look rather silly.
