### PR TITLE
Localization update: Added aliases for Norwegian verbs for GWT

### DIFF
--- a/lib/localisation/Language.js
+++ b/lib/localisation/Language.js
@@ -26,7 +26,7 @@ module.exports = function(name, vocabulary) {
     };
 
     this.localise_library = function(library) {
-        $(['given', 'when', 'then']).each(function(keyword) {
+        $(Object.keys(vocabulary)).each(function(keyword) {
             library[keyword] = function(signatures, fn, ctx) {
                 return $(signatures).each(function(signature) {
                     var signature = prefix_signature(_this.localise(keyword), signature);

--- a/lib/localisation/Norwegian.js
+++ b/lib/localisation/Norwegian.js
@@ -27,5 +27,10 @@ module.exports = (function() {
         then: '(?:[Ss]å|[Ff]forvent|[Oo]g|[Mm]en)'
     };
 
+    // Aliasing Norwegian verbs for given-when-then
+    vocabulary['gitt'] = vocabulary.given;
+    vocabulary['når'] = vocabulary.when;
+    vocabulary['så'] = vocabulary.then;
+
     return new Language('Norwegian', vocabulary);
 })();


### PR DESCRIPTION
To fully complete the Norwegian localization, I've added aliasing for the Norwegian verbs for given-when-then. If added, this allows each step-definition to be fully readable in Norwegian as well as English.

Code wise, the question is if it's acceptable to iterate through all vocabulary properties/keys, or if there needs to be a localized filter (or multiple data structures) to separate [feature, scenario, pending] from [given, when, then] when localized aliases are added.
