### PR TITLE
Added proper Norwegian localization keyword aliases for GWT

### DIFF
--- a/lib/localisation/Norwegian.js
+++ b/lib/localisation/Norwegian.js
@@ -25,7 +25,11 @@ module.exports = (function() {
         given: '(?:[Gg]itt|[Mm]ed|[Oo]g|[Mm]en|[Uu]nntatt)',
         when: '(?:[Nn]år|[Oo]g|[Mm]en)',
         then: '(?:[Ss]å|[Ff]forvent|[Oo]g|[Mm]en)',
-        _steps: ['given', 'when', 'then', 'gitt', 'når', 'så']
+        _steps: ['given', 'when', 'then', 'gitt', 'når', 'så'],
+        // Also aliasing Norwegian verbs for given-when-then for signature-lookup
+        get gitt () { return this.given },
+        get når () { return this.when },
+        get så () { return this.then }
     };
 
     return new Language('Norwegian', vocabulary);


### PR DESCRIPTION
Sorry. I obviously didn't test the Norwegian support for both Given-When-Then and Gitt-Når-Så extensively enough. With the current 0.8.4 only GWT works, due to the signature-localisation-lookup in Language.js This is what we Norwegians get for mixing English and Norwegian in code when doing BDD...

I've added the Norwegian Gitt-Når-Så as property getters as to make them as aliases. If this seems like to much functionality in the vocabulary dictionary, it can be done as a function instead. For example:

// Aliasing Norwegian verbs for given-when-then
var vocabulary = new function() {
    this.feature = '(?:[Ee]genskap)';
        this.scenario = '(?:[Ss]cenario)';
        this.pending = 'Avventer';
        this.given = this.gitt = '(?:[Gg]itt|[Mm]ed|[Oo]g|[Mm]en|[Uu]nntatt)';
        this.when = this.når = '(?:[Nn]år|[Oo]g|[Mm]en)';
        this.then = this.så = '(?:[Ss]å|[Ff]forvent|[Oo]g|[Mm]en)';
        this._steps = ['given', 'when', 'then', 'gitt', 'når', 'så'];
};
