### PR TITLE
Better detection of node.js

### DIFF
--- a/lib/Platform.js
+++ b/lib/Platform.js
@@ -9,9 +9,8 @@ function Platform() {
     }
 
     function is_node() {
-        return typeof global != 'undefined' &&
-               typeof global.process != 'undefined' &&
-               global.process.title == 'node';
+        return typeof module != 'undefined' &&
+               typeof module.exports != 'undefined';
     }
 
     function is_browser() {


### PR DESCRIPTION
Better detection of node.js (based on how Underscore does it)
When running on Mocha and CoffeeScript, it wasn't detecting it was running on node.js
