### PR TITLE
Adding support for bower package manager

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "yadda",
+  "version": "0.10.1",
+  "homepage": "https://github.com/acuminous/yadda",
+  "description": "A true BDD framework for JavaScript",
+  "main": "lib/index.js",
+  "moduleType": [
+    "node"
+  ],
+  "keywords": [
+    "BDD",
+    "Specification",
+    "Natural",
+    "Test",
+    "Behaviour",
+    "Driven",
+    "Jasmine",
+    "Mocha",
+    "QUnit",
+    "Nodeunit"
+  ],
+  "authors": [
+    "Stephen Cresswell"
+  ],
+  "license": "Apache2",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Added a bower.json file with information pulled in from component.json. Not sure how effective this file is at enabling bower support, but it should be added for people writing test harnesses in yadda for their yeoman generators or people using bower as their package manager of choice. 
