### PR TITLE
Provide each Example with its own set of annotations

### DIFF
--- a/lib/parsers/FeatureParser.js
+++ b/lib/parsers/FeatureParser.js
@@ -372,9 +372,15 @@ var Examples = function(scenario) {
     this.expand = function(scenario) {
         validate();
         return examples.collect(function(example) {
+            var annotations = {};
+            Object.keys(scenario.annotations).forEach(
+                function (key) {
+                    annotations[key] = scenario.annotations;
+                }
+            );
             return {
                 title: substitute(example, scenario.title),
-                annotations: scenario.annotations,
+                annotations: annotations,
                 description: substitute_all(example, scenario.description),
                 steps: substitute_all(example, scenario.steps)
             };


### PR DESCRIPTION
I have a use case where I'd like to be able to dynamically mark a particular scenario as generated by an entry in an Examples table as pending. This patch provides a shallow clone of the original scenario annotations object for the individual table generated scenarios such that those scenarios can then be assigned a pending annotation (or any other really) and not have it effect the rest of the scenarios from that table. Normal marking of the scenario with @Pending still causes all generated scenarios from the table to be pending.

I went with a shallow clone here because it was the easiest to implement. I'm not sure if ES5 code is acceptable. If ES3 would be preferred I can swap it out.
