### PR TITLE
Use correct spec file in jasmine-webdriver example.

### DIFF
--- a/examples/jasmine-webdriver/bin/example.bat
+++ b/examples/jasmine-webdriver/bin/example.bat
@@ -2,5 +2,5 @@
 setlocal
 
 :run
-node_modules\.bin\jasmine-node --verbose spec\bottles-spec.js
+node_modules\.bin\jasmine-node --verbose spec\google-spec.js
 endlocal


### PR DESCRIPTION
example.bat file uses 'bottles-spec.js'. It should be 'google-spec.js'