### PR TITLE
Step name in context step definition

### DIFF
--- a/lib/Macro.js
+++ b/lib/Macro.js
@@ -41,7 +41,7 @@ var Macro = function(signature, parsed_signature, macro, macro_context) {
     };
 
     this.interpret = function(step, scenario_context, next) {
-        var context = new Context().merge(macro_context).merge(scenario_context);
+        var context = new Context().merge(macro_context).merge(scenario_context).merge({step:step});
         convert(signature_pattern.groups(step), function(err, args) {
             if (err) return next(err);
             event_bus.send(EventBus.ON_EXECUTE, { step: step, ctx: context.properties, pattern: signature_pattern.toString(), args: args });

--- a/test/MacroTests.js
+++ b/test/MacroTests.js
@@ -20,7 +20,7 @@ describe('Macro', function() {
 
         assert.ok(execution.executed, "The step code was not run");
         assert.deepEqual(execution.args.splice(0, 3), [1, 2, 3]);
-        assert.deepEqual(execution.ctx, {a: 1, b: 2});
+        assert.deepEqual(execution.ctx, {a: 1, b: 2, step: 'Easy as 1, 2, 3'});
     });
 
     it('should include step name in the context', function() {
@@ -67,7 +67,7 @@ describe('Macro', function() {
         var event = listener.events[0];
         assert.equal(event.name, EventBus.ON_EXECUTE);
         assert.equal(event.data.step, 'Easy as 1, 2, 3');
-        assert.deepEqual(event.data.ctx, {a: 1, b: 2});
+        assert.deepEqual(event.data.ctx, {a: 1, b: 2, step: 'Easy as 1, 2, 3'});
         assert.equal(event.data.pattern, "/Easy as (\\d), (\\d), (\\d)/");
         assert.deepEqual(event.data.args.slice(), ["1", "2", "3"]);
         done();
@@ -81,7 +81,7 @@ describe('Macro', function() {
 
         assert.ok(execution.executed, "The step code was not run");
         assert.deepEqual(execution.args.splice(0, 1), ["1\n2\n3"]);
-        assert.deepEqual(execution.ctx, {a: 1, b: 2});
+        assert.deepEqual(execution.ctx, {a: 1, b: 2, step: 'Easy as 1\n2\n3'});
     });
 
     it('should convert parameters', function() {

--- a/test/MacroTests.js
+++ b/test/MacroTests.js
@@ -23,6 +23,15 @@ describe('Macro', function() {
         assert.deepEqual(execution.ctx, {a: 1, b: 2});
     });
 
+    it('should include step name in the context', function() {
+        var execution = new Execution();
+        var args = [1, 2, 3, 'callback'];
+
+        new Macro('Easy', parsed_signature(/Easy as (\d), (\d), (\d)/), execution.code, {a: 1}).interpret("Easy as 1, 2, 3", new Context({b: 2}), fn.noop);
+
+        assert.equal(execution.ctx.step, 'Easy as 1, 2, 3')
+    });
+
     it('should provide a signature that can be used to compare levenshtein distance', function() {
         $([
             /the quick brown fox/,


### PR DESCRIPTION
we would like to have access to the step name inside the context of a stepdefinition so that we can pass it to the assertion lib for nicer reporting.