### PR TITLE
remove describe.only from FeatureParser

### DIFF
--- a/test/FeatureParserTests.js
+++ b/test/FeatureParserTests.js
@@ -13,7 +13,7 @@ var Pirate = require('../lib/index').localisation.Pirate;
 var English = require('../lib/index').localisation.English;
 
 
-describe.only('FeatureParser', function() {
+describe('FeatureParser', function() {
 
     afterEach(function() {
         Localisation.default = English;


### PR DESCRIPTION
FeatureParser has a describe.only in it, so at the minute travis etc isn't actually running the full test suite!