### PR TITLE
Fix by_ascending_score sorting function

### DIFF
--- a/lib/Competition.js
+++ b/lib/Competition.js
@@ -68,7 +68,11 @@ var Competition = function(step, macros, last_macro) {
     }
 
     function by_ascending_score(a, b) {
-        return b.score.beats(a.score);
+        if (b.score.equals(a.score)) {
+            return 0;
+        } else {
+            return b.score.beats(a.score) ? 1 : -1;
+        }
     }
 
     function by_winning_score(result) {


### PR DESCRIPTION
I had some issues running yadda for frontend tests. In Chrome everything was as expected, while in PhantomJS tests were failing because for steps with more than one available macro the worse macro (bigger Levenshtein distance) was picked.

The error boiled down to https://github.com/acuminous/yadda/blob/master/lib/Competition.js#L71 returning a boolean value, while `Array.prototype.sort` expects a number (-1/0/1). 

This change fixes it. After that PhantomJS and Chrome consistently picked the right step macro!