### PR TITLE
Fix for Jasmine swallowing errors in steps

### DIFF
--- a/lib/plugins/mocha/StepLevelPlugin.js
+++ b/lib/plugins/mocha/StepLevelPlugin.js
@@ -52,7 +52,7 @@ module.exports.init = function(options) {
                 }
                 abort = true;
                 iterator(step, function(err) {
-                    if (err) return done(err);
+                    if (err) return (done.fail || done)(err);
                     abort = false;
                     done();
                 });


### PR DESCRIPTION
Jasmine doesn't do anything if we call done(err) so it needs to be notified by done.fail(err) instead.

This problem stops any errors in the javascript from being correctly identified and failing a test.

This is easily reproducible in the jasmine example by throwing an error in any step. Jasmine differs from mocha in that it will ignore if the error is passed back through that callback so we have to be more explicit.

I've tested this in our application and it fixes the issue and errors correctly bubble up and fail the build.